### PR TITLE
fix error: sh: -c: line 0: syntax error near unexpected token `('

### DIFF
--- a/EvmUtils/convert_EVM_outputs_to_GFF3.pl
+++ b/EvmUtils/convert_EVM_outputs_to_GFF3.pl
@@ -58,7 +58,7 @@ foreach my $accession (keys %base_directories) {
     
     print "// Processing $accession, $base_directory\n";
     
-    my $cmd = "$bindir/EVM_to_GFF3.pl $base_directory/$output_file_name $accession > $base_directory/$output_file_name.gff3";
+    my $cmd = "$bindir/EVM_to_GFF3.pl $base_directory/$output_file_name '$accession' > $base_directory/$output_file_name.gff3";
     my $ret = system $cmd;
     if ($ret) {
         die "Error, cmd $cmd died with ret $ret ";


### PR DESCRIPTION
This was caused by `(` or `)` in chr name.

```
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `miniconda/envs/anno/bin/EvmUtils/EVM_to_GFF3.pl SE9.partitions/utg32_pilon_pilon_pilon_15090909_15096092____1_5183/evm.out utg32_pilon_pilon_pilon:15090909-15096092(+):1-5183 > SE9.partitions/utg32_pilon_pilon_pilon_15090909_15096092____1_5183/evm.out.gff3'
Error, cmd miniconda/envs/anno/bin/EvmUtils/EVM_to_GFF3.pl SE9.partitions/utg32_pilon_pilon_pilon_15090909_15096092____1_5183/evm.out utg32_pilon_pilon_pilon:15090909-15096092(+):1-5183 > SE9.partitions/utg32_pilon_pilon_pilon_15090909_15096092____1_5183/evm.out.gff3 died with ret 256  at
miniconda/envs/anno/bin/EvmUtils/convert_EVM_outputs_to_GFF3.pl line 64.
```